### PR TITLE
ci: add strict flag

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,4 +15,4 @@ jobs:
           version: v3.9.3
 
       - name: Linting chart
-        run: helm lint
+        run: helm lint --strict


### PR DESCRIPTION
Add a strict flag for command helm lint. It fail on lint warnings.